### PR TITLE
Updates for python 3.10 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-# gRPC based fork of [baonguyen2604/raft-consensus](https://github.com/baonguyen2604/raft-consensus)
-This fork was created to allow the use of gRPC for the message mechanism instead of UDP.
-
-Planned changes:
-- Add gRPC support, retaining UDP functions and preserving upstream compatibility as much as possible
-- Add startup pause/continue controls so that manually starting many nodes will not require long timeouts
-- Add log persistence
-
-Completed changes:
- - None
-
 # Raft Distributed Consensus
 Simple implementation of [Raft Consensus Algorithm](raft.github.io) using Python for fault-tolerant distributed systems. Supports proper leader election and log replication.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# gRPC based fork of [baonguyen2604/raft-consensus](https://github.com/baonguyen2604/raft-consensus)
+This fork was created to allow the use of gRPC for the message mechanism instead of UDP.
+
+Planned changes:
+- Add gRPC support, retaining UDP functions and preserving upstream compatibility as much as possible
+- Add startup pause/continue controls so that manually starting many nodes will not require long timeouts
+- Add log persistence
+
+Completed changes:
+ - None
+
 # Raft Distributed Consensus
 Simple implementation of [Raft Consensus Algorithm](raft.github.io) using Python for fault-tolerant distributed systems. Supports proper leader election and log replication.
 

--- a/bank_teller/run_server.py
+++ b/bank_teller/run_server.py
@@ -20,7 +20,11 @@ def run_server():
         for i in range(4, argc):
             neis.append(('localhost', int(sys.argv[i])))
 
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+
     state = raft.state_follower()
     log = []
     dummy_index = {
@@ -29,7 +33,9 @@ def run_server():
         'balance': None
     }
     log.append(dummy_index)
-    server = raft.create_server(name='raft', state=state, log=log, neiports=neis, port=server_port, loop=loop)
+    async def main():
+        server = raft.create_server(name='raft', state=state, log=log, neiports=neis, port=server_port, loop=loop)
+    loop.run_until_complete(main())
     loop.run_forever()
     loop.stop()
 

--- a/raft/servers/server.py
+++ b/raft/servers/server.py
@@ -17,7 +17,7 @@ class Server(object):
         self._port = port
         self._neiports = neiports
         self._loop = loop
-        self._queue = asyncio.Queue(loop=self._loop)
+        self._queue = asyncio.Queue()
         self._sock = socket(AF_INET, SOCK_DGRAM)
         self._sock.bind(self._port)
         self._nei_portnum = []


### PR DESCRIPTION

Some asyncio features are deprecated or work differently on 3.10. Tested on 3.8.10 and 3.10.4. Not sure how far back the changes will work, but any 3.8+ almost certainly, probably 3.7+.